### PR TITLE
Multiple Projects with PlatformIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # All Firmware
 Contains all microcontroller code for any and all boards we develop.
 See specific dir documentation for more details.
-## Setup:
+## Setup
 We use the PlatformIO build system. To get started, follow the
 instructions on this page: https://platformio.org/install. You
 can either install the VS Code extension, or the CLI directly.
-Once it's installed, you can build the code by running `pio run`
-in your terminal. Works on windows, mac and linux.
+Once it's installed, you can build all environments by running
+`pio run` in your terminal. Works on windows, mac and linux.
+
+## Environments
+You can build the code for a specific rocket by running `pio run -e <name>`.
+For example, build the E1 code by running `pio run -e E1`. To upload
+the code for a specific environment, run `pio run -e <name> -t upload`.
+If the specified environment is for Teensy, it should open the teensy loader
+GUI.

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,10 +8,11 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:teensy41]
+[env:E1]
 platform = teensy
 board = teensy41
 framework = arduino
+src_filter = +<E1_coldflow.cpp>
 lib_deps = 
 	adafruit/Adafruit BusIO@^1.7.1
 	adafruit/Adafruit MCP9600 Library@^1.1.1
@@ -20,3 +21,9 @@ lib_deps =
 	adafruit/Adafruit BNO055@^1.4.3
 	greiman/SdFat@^2.0.4
 	adafruit/Adafruit BMP3XX Library@^2.0.1
+
+[env:E3]
+platform = teensy
+board = teensy41
+framework = arduino
+src_filter = +<E3.cpp>

--- a/src/E3.cpp
+++ b/src/E3.cpp
@@ -1,0 +1,5 @@
+#include <Arduino.h>
+
+int main(int argc, char** argv) {
+  return 0;
+}


### PR DESCRIPTION
This PR adds the ability to have multiple projects in the `src` directory. For instance, to build the E1 code, just run `pio run -e E1`. To build the E3 code, run `pio run -e E3`. To upload either of these projects, run `pio run -e <name> -t upload`.