### PR TITLE
Neha/pcktcounter

### DIFF
--- a/lib/common_fw/common_fw.cpp
+++ b/lib/common_fw/common_fw.cpp
@@ -15,7 +15,6 @@ union floatArrToBytes farrbconvert;
  *
  */
 bool write_to_SD(std::string message, const char * file_name) {
-    using namespace std;
     sdBuffer->enqueue(message);
     if(sdBuffer->length >= 40) {
       if(file.open(file_name, O_RDWR | O_APPEND)) {

--- a/lib/common_fw/common_fw.cpp
+++ b/lib/common_fw/common_fw.cpp
@@ -9,6 +9,7 @@ SdFat sd;
 File file;
 struct Queue *sdBuffer;
 union floatArrToBytes farrbconvert;
+int packetCounter = 0;
 
 /**
  *
@@ -106,6 +107,15 @@ int decode_received_packet(String packet, valveInfo *valve, valveInfo valves[], 
   } else {
     return -1;
   }
+}
+
+void readPacketCounter(float *data) {
+    data[0] = packetCounter;
+    data[1] = -1;
+  }
+
+void incrementPacketCounter() {
+    packetCounter+=1;
 }
 
 /**

--- a/lib/common_fw/common_fw.cpp
+++ b/lib/common_fw/common_fw.cpp
@@ -7,9 +7,9 @@
 
 SdFat sd;
 File file;
+int packetCounter = 0;
 struct Queue *sdBuffer;
 union floatArrToBytes farrbconvert;
-int packetCounter = 0;
 
 /**
  *
@@ -68,7 +68,7 @@ String make_packet(int id, bool error) {
   }
   packet_content += check_;
   String packet = "{" + packet_content + "}";
-
+  incrementPacketCounter();
   return packet;
 }
 

--- a/lib/common_fw/common_fw.cpp
+++ b/lib/common_fw/common_fw.cpp
@@ -18,16 +18,14 @@ bool write_to_SD(std::string message, const char * file_name) {
     using namespace std;
     sdBuffer->enqueue(message);
     if(sdBuffer->length >= 40) {
-      fstream currfile;
-      currfile.open(file_name, fstream::out | fstream::app);
-      if(currfile.is_open()) {
+      if(file.open(file_name, O_RDWR | O_APPEND)) {
         int initialLength = sdBuffer->length;
         for(int i = 0; i < initialLength; i++) {
           char *msg = sdBuffer->dequeue();
-          currfile.write(msg, sizeof(msg)); 
+          file.write(msg, sizeof(msg)); 
           free(msg);
         }
-        currfile.close();
+        file.close();
         return true;
       } else {        //If the file didn't open
           return false;
@@ -163,18 +161,6 @@ uint16_t Fletcher16(uint8_t *data, int count) {
     }
   }
   return (sum2 << 8) | sum1;
-}
-
-/*
- * empty implementation of _open, this stub function is required by stdlib
- * to allow linking
- */
-extern "C" int _open(const char *name, int flags, int mode)
-{
-    static_cast<void>(name);
-    static_cast<void>(flags);
-    static_cast<void>(mode);
-    return -1;   
 }
 
 void debug(String str, int flag){

--- a/lib/common_fw/common_fw.cpp
+++ b/lib/common_fw/common_fw.cpp
@@ -15,19 +15,22 @@ int packetCounter = 0;
  *
  */
 bool write_to_SD(std::string message, const char * file_name) {
+    using namespace std;
     sdBuffer->enqueue(message);
     if(sdBuffer->length >= 40) {
-      if(file.open(file_name, O_RDWR | O_APPEND)) {
+      fstream currfile;
+      currfile.open(file_name, fstream::out | fstream::app);
+      if(currfile.is_open()) {
         int initialLength = sdBuffer->length;
         for(int i = 0; i < initialLength; i++) {
           char *msg = sdBuffer->dequeue();
-          file.write(msg);
+          currfile.write(msg, sizeof(msg)); 
           free(msg);
         }
-        file.close();
+        currfile.close();
         return true;
       } else {        //If the file didn't open
-        return false;
+          return false;
       }
     }
     return true;
@@ -160,6 +163,18 @@ uint16_t Fletcher16(uint8_t *data, int count) {
     }
   }
   return (sum2 << 8) | sum1;
+}
+
+/*
+ * empty implementation of _open, this stub function is required by stdlib
+ * to allow linking
+ */
+extern "C" int _open(const char *name, int flags, int mode)
+{
+    static_cast<void>(name);
+    static_cast<void>(flags);
+    static_cast<void>(mode);
+    return -1;   
 }
 
 void debug(String str, int flag){

--- a/lib/common_fw/common_fw.h
+++ b/lib/common_fw/common_fw.h
@@ -13,6 +13,8 @@
 #include <TimeLib.h>
 #include <Arduino.h>
 #include <Wire.h>
+#include <iostream>
+#include <fstream>
 
 
 struct Queue {
@@ -108,6 +110,7 @@ struct valveInfo {
 };
 
 
+
 String make_packet (int id, bool error);
 uint16_t Fletcher16 (uint8_t *data, int count);
 void chooseValveById (int id, struct valveInfo *valve, valveInfo valves[], int numValves);
@@ -117,6 +120,7 @@ void readPacketCounter(float *data);
 void incrementPacketCounter();
 void take_action(valveInfo *valve, int action);
 uint16_t Fletcher16(uint8_t *data, int count);
+extern "C" int _open(const char *name, int flags, int mode);
 void debug(String str, int debug);
 
 extern SdFat sd;
@@ -128,6 +132,8 @@ extern union floatArrToBytes farrbconvert;
 extern struct sensorInfo *sensors;
 extern struct valveInfo *valves;
 
-int packetCounter;
 
 #endif // _COMMON_H_
+
+
+

--- a/lib/common_fw/common_fw.h
+++ b/lib/common_fw/common_fw.h
@@ -129,10 +129,6 @@ extern union floatArrToBytes farrbconvert;
 extern struct sensorInfo *sensors;
 extern struct valveInfo *valves;
 extern int packetCounter;
-
-
-
-
 #endif // _COMMON_H_
 
 

--- a/lib/common_fw/common_fw.h
+++ b/lib/common_fw/common_fw.h
@@ -131,6 +131,9 @@ extern struct Queue *sdBuffer;
 extern union floatArrToBytes farrbconvert;
 extern struct sensorInfo *sensors;
 extern struct valveInfo *valves;
+extern int packetCounter;
+
+
 
 
 #endif // _COMMON_H_

--- a/lib/common_fw/common_fw.h
+++ b/lib/common_fw/common_fw.h
@@ -113,6 +113,8 @@ uint16_t Fletcher16 (uint8_t *data, int count);
 void chooseValveById (int id, struct valveInfo *valve, valveInfo valves[], int numValves);
 bool write_to_SD(std::string message, const char * file_name);
 int decode_received_packet(String packet, valveInfo *valve, valveInfo valves[], int numValves);
+void readPacketCounter(float *data);
+void incrementPacketCounter();
 void take_action(valveInfo *valve, int action);
 uint16_t Fletcher16(uint8_t *data, int count);
 void debug(String str, int debug);
@@ -125,5 +127,7 @@ extern struct Queue *sdBuffer;
 extern union floatArrToBytes farrbconvert;
 extern struct sensorInfo *sensors;
 extern struct valveInfo *valves;
+
+int packetCounter;
 
 #endif // _COMMON_H_

--- a/lib/common_fw/common_fw.h
+++ b/lib/common_fw/common_fw.h
@@ -13,8 +13,6 @@
 #include <TimeLib.h>
 #include <Arduino.h>
 #include <Wire.h>
-#include <iostream>
-#include <fstream>
 
 
 struct Queue {
@@ -120,7 +118,6 @@ void readPacketCounter(float *data);
 void incrementPacketCounter();
 void take_action(valveInfo *valve, int action);
 uint16_t Fletcher16(uint8_t *data, int count);
-extern "C" int _open(const char *name, int flags, int mode);
 void debug(String str, int debug);
 
 extern SdFat sd;

--- a/src/E1_coldflow/E1_coldflow.cpp
+++ b/src/E1_coldflow/E1_coldflow.cpp
@@ -182,3 +182,5 @@ void sensorReadFunc(int id) {
       break;
   }
 }
+
+

--- a/src/E1_coldflow/E1_coldflow.cpp
+++ b/src/E1_coldflow/E1_coldflow.cpp
@@ -68,7 +68,6 @@ void setup() {
   if (!res) {
     packet = make_packet(101, true);
     RFSerial.println(packet);
-    incrementPacketCounter();
   }
 
   debug("Opening File", DEBUG);
@@ -83,7 +82,6 @@ void setup() {
   if(!write_to_SD(start, file_name)) { // if unable to write to SD, send error packet
     packet = make_packet(101, true);
     RFSerial.println(packet);
-    incrementPacketCounter();
   }
 
   // config::setup();
@@ -120,7 +118,6 @@ void loop() {
       Serial.println(packet);
       #if SERIAL_INPUT != 1
         RFSerial.println(packet);
-        incrementPacketCounter();
       #endif
       write_to_SD(packet.c_str(), file_name);
     }
@@ -143,7 +140,6 @@ void loop() {
 
     #if SERIAL_INPUT != 1
         RFSerial.println(packet);
-        incrementPacketCounter();
       #endif
     write_to_SD(packet.c_str(), file_name);
   }

--- a/src/E1_coldflow/E1_coldflow.cpp
+++ b/src/E1_coldflow/E1_coldflow.cpp
@@ -68,6 +68,7 @@ void setup() {
   if (!res) {
     packet = make_packet(101, true);
     RFSerial.println(packet);
+    incrementPacketCounter();
   }
 
   debug("Opening File", DEBUG);
@@ -82,6 +83,7 @@ void setup() {
   if(!write_to_SD(start, file_name)) { // if unable to write to SD, send error packet
     packet = make_packet(101, true);
     RFSerial.println(packet);
+    incrementPacketCounter();
   }
 
   // config::setup();
@@ -103,6 +105,7 @@ void loop() {
   // process command
   if (RFSerial.available() > 0) {
     int i = 0;
+    
     while (RFSerial.available()) {
       command[i] = RFSerial.read();
       Serial.print(command[i]);
@@ -117,6 +120,7 @@ void loop() {
       Serial.println(packet);
       #if SERIAL_INPUT != 1
         RFSerial.println(packet);
+        incrementPacketCounter();
       #endif
       write_to_SD(packet.c_str(), file_name);
     }
@@ -136,8 +140,10 @@ void loop() {
     sensorReadFunc(sensor->id);
     packet = make_packet(sensor->id, false);
     Serial.println(packet);
+
     #if SERIAL_INPUT != 1
         RFSerial.println(packet);
+        incrementPacketCounter();
       #endif
     write_to_SD(packet.c_str(), file_name);
   }
@@ -168,6 +174,9 @@ void sensorReadFunc(int id) {
       farrbconvert.sensorReadings[3]=0;
       farrbconvert.sensorReadings[4]=-1;
       break;
+    case 5:
+      readPacketCounter(farrbconvert.sensorReadings);
+
     default:
       Serial.println("some other sensor");
       break;

--- a/src/E1_coldflow/E1_coldflow.cpp
+++ b/src/E1_coldflow/E1_coldflow.cpp
@@ -178,5 +178,3 @@ void sensorReadFunc(int id) {
       break;
   }
 }
-
-

--- a/src/E1_coldflow/config.h
+++ b/src/E1_coldflow/config.h
@@ -74,8 +74,6 @@ namespace config {
     sensors[3] = {"Aux temp",      FLIGHT_BRAIN_ADDR, 4, 1};
     sensors[5] = {"Number Packets Sent", FLIGHT_BRAIN_ADDR, 5, 10};
 
-
-
     debug("Initializing valves", DEBUG);
     valves = new valveInfo[numValves];
     valves[0] = {"LOX 2 Way", 20, &(Solenoids::armLOX), &(Solenoids::disarmLOX), &(Solenoids::getAllStates)};

--- a/src/E1_coldflow/config.h
+++ b/src/E1_coldflow/config.h
@@ -28,8 +28,9 @@ const int numPressureTransducers = 5;
 int ptAdcIndices[numPressureTransducers] = {0, 0, 0, 0, 1};
 int ptAdcChannels[numPressureTransducers] = {0, 1, 2, 3, 0};
 
-const uint8_t numSensors = 4;
+const uint8_t numSensors = 5;
 sensorInfo *sensors;
+
 
 const int numValves = 9;
 struct valveInfo *valves;
@@ -71,6 +72,9 @@ namespace config {
     sensors[1] = {"All Pressure",  FLIGHT_BRAIN_ADDR, 1, 1};
     sensors[2] = {"Battery Stats", FLIGHT_BRAIN_ADDR, 2, 3};
     sensors[3] = {"Aux temp",      FLIGHT_BRAIN_ADDR, 4, 1};
+    sensors[5] = {"Number Packets Sent", FLIGHT_BRAIN_ADDR, 5, 1};
+
+
 
     debug("Initializing valves", DEBUG);
     valves = new valveInfo[numValves];

--- a/src/E1_coldflow/config.h
+++ b/src/E1_coldflow/config.h
@@ -72,7 +72,7 @@ namespace config {
     sensors[1] = {"All Pressure",  FLIGHT_BRAIN_ADDR, 1, 1};
     sensors[2] = {"Battery Stats", FLIGHT_BRAIN_ADDR, 2, 3};
     sensors[3] = {"Aux temp",      FLIGHT_BRAIN_ADDR, 4, 1};
-    sensors[5] = {"Number Packets Sent", FLIGHT_BRAIN_ADDR, 5, 1};
+    sensors[5] = {"Number Packets Sent", FLIGHT_BRAIN_ADDR, 5, 10};
 
 
 


### PR DESCRIPTION
followed Vamshi's instructions to add packet counter to common_fw, used in E1_coldflow to increment when sending packets via RF & added as sensor reading
- fixed build errors from earlier
- replaced broken file.write() line with code from ofstream library
- would not link since _open system call was not defined by OS for some reason --> provided stub empty implementation of _open so it fails safely for now 