### PR TITLE
use cryo therms for lox adapter tree heaters

### DIFF
--- a/lib/Thermocouple/Cryo_Thermocouple.h
+++ b/lib/Thermocouple/Cryo_Thermocouple.h
@@ -47,6 +47,11 @@ namespace Thermocouple {
       data[_numSensors] = -1;
     }
 
+    void readSpecificCryoTemp(int index, float *data){
+      data[0] = _cryo_amp_boards[index]->readThermocouple();
+      data[1] = -1;
+    }
+
     int freeAllResources() {
         free(_cryo_amp_boards);
         free(_addrs);

--- a/lib/Thermocouple/Cryo_Thermocouple.h
+++ b/lib/Thermocouple/Cryo_Thermocouple.h
@@ -15,9 +15,11 @@ namespace Thermocouple {
     Adafruit_MCP9600 ** _cryo_amp_boards;
     int * _addrs;
     int _numSensors;
+    float * _latestReads;
 
     int init(int numSensors, int * addrs, _themotype * types) { // assume that numSensors is < max Size of packet. Add some error checking here
       _addrs = (int *)malloc(numSensors);
+      _latestReads = (float *)malloc(numSensors);
       _cryo_amp_boards = (Adafruit_MCP9600 **)malloc(numSensors * sizeof(Adafruit_MCP9600));
 
       _numSensors = numSensors;
@@ -43,18 +45,20 @@ namespace Thermocouple {
     void readCryoTemps(float *data) {
       for (int i = 0; i < _numSensors; i++) {
         data[i] = _cryo_amp_boards[i]->readThermocouple();
+        _latestReads[i] = data[i];
       }
       data[_numSensors] = -1;
     }
 
-    void readSpecificCryoTemp(int index, float *data){
-      data[0] = _cryo_amp_boards[index]->readThermocouple();
+    void readSpecificCryoTemp(int index, float *data) {
+      data[0] = _latestReads[index];
       data[1] = -1;
     }
 
     int freeAllResources() {
         free(_cryo_amp_boards);
         free(_addrs);
+        free(_latestReads);
         return 0;
     }
 

--- a/lib/tempController/tempController.cpp
+++ b/lib/tempController/tempController.cpp
@@ -1,0 +1,35 @@
+/*
+  tempControl.cpp - A c++ algorithm that maintains the temperature at a given set point.
+  Two versions: One very simple, naive algorithm. (Needs to be empirically tested to verify).
+  Another, more complex control loop that should reject all disturbances quite well.
+  Created by Vamshi Balanaga, Oct 7, 2020.
+*/
+#include "tempController.h"
+
+TempController::TempController(int tempSetPoint, int algorithmChoice, int heaterPin):
+  _heaterPin(heaterPin),
+  _algorithmChoice(algorithmChoice),
+  _setPointTemp(tempSetPoint)
+ {
+  if (algorithmChoice > 2 || algorithmChoice < 0) {
+    exit(0);
+  }
+}
+
+int TempController::calculateOutput(float currTemp) {
+  int voltageOut = 0;
+  if (_algorithmChoice == 1) { // naive
+    voltageOut = (int)(k_p * (_setPointTemp - currTemp));
+    return max(0, min(255, voltageOut));
+  } else if (_algorithmChoice == 2) { // linear control theory solution
+    return controller->calculate(_setPointTemp, currTemp);
+  } else {
+    return -1;
+  }
+}
+
+float TempController::controlTemp(float currTemp) {
+  _heaterOutput = calculateOutput(currTemp);
+  analogWrite(_heaterPin, _heaterOutput);
+  return ((float)(_heaterOutput) / 255) * 24; // heater runs at 24 V
+}

--- a/lib/tempController/tempController.cpp
+++ b/lib/tempController/tempController.cpp
@@ -12,7 +12,7 @@ TempController::TempController(int tempSetPoint, int algorithmChoice, int heater
   _setPointTemp(tempSetPoint)
  {
   if (algorithmChoice > 2 || algorithmChoice < 0) {
-    exit(0);
+    exit(1);
   }
 }
 

--- a/lib/tempController/tempController.h
+++ b/lib/tempController/tempController.h
@@ -1,7 +1,7 @@
 /*
-  tempControl.cpp - A c++ algorithm that maintains the temperature at a given set point.
+  tempControl.h - A c++ algorithm that maintains the temperature at a given set point.
   Two versions: One very simple, naive algorithm. (Needs to be empirically tested to verify).
-  Another, very complex control loop that should reject all disturbances quite well.
+  Another, more complex control loop that should reject all disturbances quite well.
   Created by Vamshi Balanaga, Oct 7, 2020.
 */
 
@@ -12,49 +12,22 @@
 
 using namespace std;
 
-namespace tempController {
-  int _algorithmChoice; // 1 - naive, 2 - actual control theory
-  int _setPointTemp;
-  int _heaterPin = 0;
-  int _heaterOutput = 0;
+class TempController {
+  private:
+    int _algorithmChoice; // 1 - naive, 2 - actual control theory
+    int _setPointTemp;
+    int _heaterPin = 0;
+    int _heaterOutput = 0;
 
-  float k_p = 100;
-  float k_i = 0.0000001; // low because t is in millis
-  float k_d = 1000;
+    float k_p = 100;
+    float k_i = 0.0000001; // low because t is in millis
+    float k_d = 1000;
 
-  PID *controller = new PID(255, 0, k_p, k_i, k_d);
+    PID *controller = new PID(255, 0, k_p, k_i, k_d);
 
-  int init(int tempSetPoint, int algorithmChoice, int heaterPin) {
-    if (algorithmChoice > 2 || algorithmChoice < 0) {
-      return -1;
-    }
-    _heaterPin = heaterPin;
-    _algorithmChoice = algorithmChoice;
-    _setPointTemp = tempSetPoint;
-    return 0;
-  }
-
-  int calculateOutput(float currTemp) {
-    int voltageOut = 0;
-    if (_algorithmChoice == 1) { // naive
-      voltageOut = (int)(k_p * (_setPointTemp - currTemp));
-      return max(0, min(255, voltageOut));
-      // if(voltageOut > 0){
-      //   return 1; // this threshold is dependent on the values of k_p, k_i, k_d;
-      // } else {
-      //   return 0;
-      // }
-    } else if (_algorithmChoice == 2) { // linear control theory solution
-      return controller->calculate(_setPointTemp, currTemp);
-    } else {
-      return -1;
-    }
-  }
-
-  float controlTemp(float currTemp) {
-    _heaterOutput = calculateOutput(currTemp);
-    analogWrite(_heaterPin, _heaterOutput);
-    return ((float)(_heaterOutput) / 255) * 24; // heater runs at 24 V
-  }
+  public:
+    TempController(int tempSetPoint, int algorithmChoice, int heaterPin);
+    int calculateOutput(float currTemp);
+    float controlTemp(float currTemp);
 };
 #endif

--- a/src/E1_coldflow/config.h
+++ b/src/E1_coldflow/config.h
@@ -11,9 +11,10 @@
 std::string str_file_name = "E1_speed_test_results.txt";
 const char * file_name = str_file_name.c_str();
 
-const int numCryoTherms = 2;
-int cryoThermAddrs[numCryoTherms] = {0x60, 0x67};
-_themotype cryoTypes[numCryoTherms] = {MCP9600_TYPE_J, MCP9600_TYPE_T};
+const int numCryoTherms = 4;
+// therm[2] = lox adapter tree pt, therm[3] = lox adapter tree gems
+int cryoThermAddrs[numCryoTherms] = {0x60, 0x67, 0x62, 0x64};
+_themotype cryoTypes[numCryoTherms] = {MCP9600_TYPE_J, MCP9600_TYPE_T, MCP9600_TYPE_T, MCP9600_TYPE_K};
 
 const int numADCSensors = 2;
 int ADSAddrs[numADCSensors] = {0b1001010, 0b1001000};
@@ -29,9 +30,8 @@ int ptAdcIndices[numPressureTransducers] = {0, 0, 0, 0, 1};
 int ptAdcChannels[numPressureTransducers] = {0, 1, 2, 3, 0};
 int ptTypes[numPressureTransducers] = {1, 1, 1, 1, 2};
 
-const uint8_t numSensors = 5;
+const uint8_t numSensors = 6;
 sensorInfo *sensors;
-
 
 const int numValves = 9;
 struct valveInfo *valves;
@@ -46,7 +46,8 @@ struct valveInfo *valves;
 
 #define HIGH_SOL_PIN 6
 
-#define LOX_ADAPTER_HEATER_PIN 7
+#define LOX_ADAPTER_PT_HEATER_PIN 7
+#define LOX_GEMS_HEATER_PIN 8
 
 const float batteryMonitorShuntR = 0.002; // ohms
 const float batteryMonitorMaxExpectedCurrent = 10; // amps
@@ -69,11 +70,12 @@ namespace config {
     debug("Initializing sensors", DEBUG);
     sensors = new sensorInfo[numSensors];
     // sensorInfo s = ;
-    sensors[0] = {"Temperature",   FLIGHT_BRAIN_ADDR, 0, 3}; //&(testTempRead)}, //&(Thermocouple::readTemperatureData)},
+    sensors[0] = {"Lox PT Temperature",   FLIGHT_BRAIN_ADDR, 0, 3}; //&(testTempRead)}, //&(Thermocouple::readTemperatureData)},
     sensors[1] = {"All Pressure",  FLIGHT_BRAIN_ADDR, 1, 1};
     sensors[2] = {"Battery Stats", FLIGHT_BRAIN_ADDR, 2, 3};
     sensors[3] = {"Aux temp",      FLIGHT_BRAIN_ADDR, 4, 1};
-    sensors[5] = {"Number Packets Sent", FLIGHT_BRAIN_ADDR, 5, 10};
+    sensors[4] = {"Number Packets Sent", FLIGHT_BRAIN_ADDR, 5, 10};
+    sensors[5] = {"LOX Gems Temp", FLIGHT_BRAIN_ADDR, 6, 3};
 
     debug("Initializing valves", DEBUG);
     valves = new valveInfo[numValves];
@@ -97,7 +99,7 @@ namespace config {
 
     pinMode(HIGH_SOL_PIN, OUTPUT);
 
-    pinMode(LOX_ADAPTER_HEATER_PIN, OUTPUT);
+    pinMode(LOX_ADAPTER_PT_HEATER_PIN, OUTPUT);
 
   }
 }

--- a/src/E1_coldflow/config.h
+++ b/src/E1_coldflow/config.h
@@ -69,13 +69,13 @@ namespace config {
 
     debug("Initializing sensors", DEBUG);
     sensors = new sensorInfo[numSensors];
-    // sensorInfo s = ;
-    sensors[0] = {"Lox PT Temperature",   FLIGHT_BRAIN_ADDR, 0, 3}; //&(testTempRead)}, //&(Thermocouple::readTemperatureData)},
-    sensors[1] = {"All Pressure",  FLIGHT_BRAIN_ADDR, 1, 1};
-    sensors[2] = {"Battery Stats", FLIGHT_BRAIN_ADDR, 2, 3};
-    sensors[3] = {"Aux temp",      FLIGHT_BRAIN_ADDR, 4, 1};
+    // the ordering in this array defines order of operation, not id
+    sensors[0] = {"All Pressure",  FLIGHT_BRAIN_ADDR, 1, 1};
+    sensors[1] = {"Battery Stats", FLIGHT_BRAIN_ADDR, 2, 3};
+    sensors[2] = {"Cryo Temps",      FLIGHT_BRAIN_ADDR, 4, 3};
+    sensors[3] = {"Lox PT Temperature",   FLIGHT_BRAIN_ADDR, 0, 4}; //&(testTempRead)}, //&(Thermocouple::readTemperatureData)},
     sensors[4] = {"Number Packets Sent", FLIGHT_BRAIN_ADDR, 5, 10};
-    sensors[5] = {"LOX Gems Temp", FLIGHT_BRAIN_ADDR, 6, 3};
+    sensors[5] = {"LOX Gems Temp", FLIGHT_BRAIN_ADDR, 6, 4};
 
     debug("Initializing valves", DEBUG);
     valves = new valveInfo[numValves];


### PR DESCRIPTION
Solves: https://trello.com/c/Vt5EYNsW/203-cryo-therm-heater-control-loop
Use 2 Cryo Therms for lox adapter tree.
Two heater control loops use these cryo thermocouples as inputs.
fix small bugs from @nehading's latest PR re packet counter.
Added appropriate packet information to the design sheet.