### PR TITLE
Firmware features verified on 9/25

### DIFF
--- a/fw_version.py
+++ b/fw_version.py
@@ -1,0 +1,41 @@
+import subprocess
+import os
+from datetime import datetime
+
+Import("env")
+
+def get_firmware_specifier_build_flag():
+    ret = subprocess.run(["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE, text=True)
+    build_version = ret.stdout.strip()
+    build_flag = "-D FW_COMMIT=\\\"" + build_version + "\\\""
+    print ("Firmware Revision: " + build_version)
+    return (build_flag)
+
+def get_username_build_flag():
+    name = os.getlogin()
+    build_flag = "-D FW_USERNAME=\\\"" + name + "\\\""
+    print("Username: " + name)
+    return (build_flag)
+
+def get_datetime_build_flag():
+    # date = ""
+    # date += ("0" + str(datetime.now().month))[-2:]
+    # date += ("0" + str(datetime.now().day))[-2:]
+    # date += ("0" + str(datetime.now().year))[-2:]
+    # date += ("0" + str(datetime.now().hour))[-2:]
+    # date += ("0" + str(datetime.now().minute))[-2:]
+    # date += ("0" + str(datetime.now().second))[-2:]
+    date = datetime.now().isoformat()
+    build_flag = "-D FW_BUILD_DATE=\\\"" + date + "\\\""
+    print("Build date: " + date)
+    return (build_flag)
+
+def get_project_name_build_flag():
+    pname = env["PIOENV"]
+    build_flag = "-D FW_PROJECT=\\\"" + pname + "\\\""
+    print("Firmware Project: " + pname)
+    return (build_flag)
+
+env.Append(
+    BUILD_FLAGS=[get_firmware_specifier_build_flag(), get_username_build_flag(), get_datetime_build_flag(), get_project_name_build_flag()]
+)

--- a/lib/Automation/Automation.cpp
+++ b/lib/Automation/Automation.cpp
@@ -293,8 +293,7 @@ namespace Automation {
     // flowtype = BOTH_COLD;
     Serial.println("eventlist len: " + String(_eventList.length));
     Serial.flush();
-    _startup = !Solenoids::getHPS() &&
-        !Solenoids::getLox2() && !Solenoids::getLox5() && !Solenoids::getProp5();
+    _startup = !Solenoids::getLox2() && !Solenoids::getLox5() && !Solenoids::getProp5();
     Serial.println("startup: " + String(_startup));
     if (_startup) {
       Serial.println("Eureka-1 is in Startup");

--- a/lib/common/common_fw.cpp
+++ b/lib/common/common_fw.cpp
@@ -18,8 +18,10 @@ union floatArrToBytes farrbconvert;
 
 #ifdef ETH
 EthernetUDP Udp;
+uint32_t m1 = HW_OCOTP_MAC1;
+uint32_t m2 = HW_OCOTP_MAC0;
 byte mac[] = {
-  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
+  m1 >> 8, m1 >> 0, m2 >> 24, m2 >> 16, m2 >> 8, m2 >> 0
 };
 unsigned int port = 42069; // try to find something that can be the same on gs
 const uint8_t numGrounds = 2;
@@ -81,6 +83,12 @@ int8_t processCommand(String packet) {
   }
   debug(String(data_start_index));
   int command_id = packet.substring(1,data_start_index).toInt();
+
+  if(command_id == 99){
+    sendVersion();
+    return -1;
+  }
+
   const int data_end_index = packet.indexOf('|');
   if(data_end_index == -1) {
     return -1;
@@ -135,6 +143,69 @@ int8_t processCommand(String packet) {
   }
 }
 
+void sendVersion(){
+  #ifdef FW_COMMIT
+  String fwCommit = FW_COMMIT;
+  #endif
+  #ifdef FW_USERNAME
+  String fwUsername = FW_USERNAME;
+  #endif
+  #ifdef FW_BUILD_DATE
+  String fwBuildDate = FW_BUILD_DATE;
+  #endif
+  #ifdef FW_PROJECT
+  String fwProject = FW_PROJECT;
+  #endif
+
+  // memset(farrbconvert.buffer ,0, 36);
+  // fwCommit.getBytes(farrbconvert.buffer, 8);
+  // fwUsername.getBytes(farrbconvert.buffer + 8, 8);
+  // fwProject.getBytes(farrbconvert.buffer + 16, 8);
+  // fwBuildDate.getBytes(farrbconvert.buffer + 24, 12);
+
+  // Serial.println();
+  // for(int i = 0; i<36;i++){
+  //   if(farrbconvert.buffer[i] == 0){
+  //     farrbconvert.buffer[i] = 32;
+  //   }
+  //   Serial.print(farrbconvert.buffer[i], HEX);
+  //   Serial.print(" ");
+  // }
+  // Serial.println();
+
+  // for(int i = 0; i<36;i++){
+  //   Serial.print(farrbconvert.buffer[i]);
+  // }
+
+  String packet_content = "99";
+  IPAddress currIP = Ethernet.localIP();
+  byte macBuffer[6];  // create a buffer to hold the MAC address
+  Ethernet.MACAddress(macBuffer);
+  packet_content += ",";
+  packet_content += "Board IP: " + String(currIP[0]) + "." + String(currIP[1]) + "." + String(currIP[2]) + "." + String(currIP[3]) + " ";
+  packet_content += "Board MAC: " + String(mac[0], HEX) + ":" + String(mac[1], HEX) + ":" + String(mac[2], HEX) 
+  + ":" + String(mac[3], HEX) + ":" + String(mac[4], HEX) + ":" + String(mac[5], HEX) + " ";
+  packet_content += "Git Commit Hash: " + fwCommit + " ";
+  packet_content += "Uploaded by: " + fwUsername + " ";
+  packet_content += "Project: " + fwProject + " ";
+  packet_content += "Uploaded on: " + fwBuildDate;
+
+  int count = packet_content.length();
+  char const *data = packet_content.c_str();
+  uint16_t checksum = Fletcher16((uint8_t *) data, count);
+  packet_content += "|";
+  String check_ = String(checksum, HEX);
+  while(check_.length() < 4) {
+    check_ = "0" + check_;
+  }
+  packet_content += check_;
+  String packet = "{" + packet_content + "}";
+  incrementPacketCounter();
+  Serial.println(packet);
+  #ifdef ETH
+  sendEthPacket(packet.c_str());
+  #endif
+}
 /*
  * Calculates checksum for key values being sent to ground station:
  * sensor_ID and it's corresponding data points

--- a/lib/common/common_fw.cpp
+++ b/lib/common/common_fw.cpp
@@ -6,7 +6,7 @@
 #include "common_fw.h"
 
 SdFat sd;
-File file;
+FsFile file;
 
 bool receivedCommand = false;
 

--- a/lib/common/common_fw.cpp
+++ b/lib/common/common_fw.cpp
@@ -84,11 +84,6 @@ int8_t processCommand(String packet) {
   debug(String(data_start_index));
   int command_id = packet.substring(1,data_start_index).toInt();
 
-  if(command_id == 99){
-    sendVersion();
-    return -1;
-  }
-
   const int data_end_index = packet.indexOf('|');
   if(data_end_index == -1) {
     return -1;
@@ -122,6 +117,10 @@ int8_t processCommand(String packet) {
   int _check = (int)Fletcher16((uint8_t *) data, count);
   if (_check == checksum) {
     debug("Checksum correct, taking action");
+    if(command_id == 99){
+      sendVersion();
+      return -1;
+    }
     tmpCommand = commands.get(command_id); //chooseValveById(valve_id, valve, valves, numValves);
     if (tmpCommand != nullptr) {
       debug("valid command");

--- a/lib/common/common_fw.h
+++ b/lib/common/common_fw.h
@@ -93,6 +93,7 @@ struct sensorInfo {
 
 String make_packet (int id, bool error);
 int8_t processCommand(String packet);
+void sendVersion();
 
 uint16_t Fletcher16 (uint8_t *data, int count);
 

--- a/lib/common/common_fw.h
+++ b/lib/common/common_fw.h
@@ -109,7 +109,7 @@ bool write_to_SD(std::string message, const char * file_name);
 void debug(String str);
 
 extern SdFat sd;
-extern File file;
+extern FsFile file;
 
 extern struct Queue *sdBuffer;
 

--- a/lib/linearActuators/linearActuators.h
+++ b/lib/linearActuators/linearActuators.h
@@ -59,7 +59,7 @@ namespace LinearActuators {
 
       void initINA219(TwoWire *wire, uint8_t inaAddr, float shuntR, float maxExpectedCurrent) {
         outputMonitor.begin(wire, inaAddr);
-        outputMonitor.configure(INA219_RANGE_16V, INA219_GAIN_40MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
+        outputMonitor.configure(INA219_RANGE_32V, INA219_GAIN_160MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
         outputMonitor.calibrate(shuntR, maxExpectedCurrent);
       }
 

--- a/lib/solenoids/ACSolenoids.h
+++ b/lib/solenoids/ACSolenoids.h
@@ -49,7 +49,7 @@ namespace ACSolenoids {
 
       void initINA219(TwoWire *wire, uint8_t inaAddr, float shuntR, float maxExpectedCurrent) {
         outputMonitor.begin(wire, inaAddr);
-        outputMonitor.configure(INA219_RANGE_16V, INA219_GAIN_40MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
+        outputMonitor.configure(INA219_RANGE_32V, INA219_GAIN_160MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
         outputMonitor.calibrate(shuntR, maxExpectedCurrent);
       }
 

--- a/lib/solenoids/solenoids.cpp
+++ b/lib/solenoids/solenoids.cpp
@@ -359,6 +359,8 @@ namespace Solenoids {
 
   int armPropane() {
     digitalWrite(lox_gems_pin, 1);
+    digitalWrite(prop_gems_pin, 1);
+    
     if (prop2_state == 0) {
       toggleProp2Way();
     } else {
@@ -369,6 +371,7 @@ namespace Solenoids {
 
   int disarmPropane() {
     digitalWrite(lox_gems_pin, 0);
+    digitalWrite(prop_gems_pin, 0);
     if (prop2_state == 1) {
       toggleProp2Way();
     } else {
@@ -411,7 +414,7 @@ namespace Solenoids {
 
   int openPropane() {
 
-    digitalWrite(prop_gems_pin, 1);
+    //digitalWrite(prop_gems_pin, 1);
 
     if (prop5_state == 0) {
       toggleProp5Way();
@@ -423,7 +426,7 @@ namespace Solenoids {
 
   int closePropane() {
 
-    digitalWrite(prop_gems_pin, 0);
+    //digitalWrite(prop_gems_pin, 0);
 
     if(prop5_state == 1){
       toggleProp5Way();

--- a/lib/solenoids/solenoids.cpp
+++ b/lib/solenoids/solenoids.cpp
@@ -141,7 +141,7 @@ namespace Solenoids {
     data[5] = prop_G.outputMonitor.readShuntCurrent();
     data[6] = _pressurantSolenoidMonitor->getLoadCurrent(_pressurantSolenoidMonitorShuntR);
     data[7] = 0;
-    data[8] = 0;
+    data[8] = -1;
   }
 
   void getAllVoltages(float *data) {
@@ -157,6 +157,7 @@ namespace Solenoids {
     data[5] = prop_G.outputMonitor.readBusVoltage();
     data[6] = _pressurantSolenoidMonitor->getADCInVoltage() * 162.7 / 4.7;
     data[7] = _pressurantSolenoidMonitor->getInputVoltage();
+    //Serial.println(data[7]);
     data[8] = -1;
   }
     void overCurrentCheck(float *data, float current_limit) {
@@ -178,11 +179,10 @@ namespace Solenoids {
           case 3 : closePropane();break;
         }
 
-        data[7] = 1; //flag for if there's an issue: usually 0
-        if (data[8] == -1) {data[8] = 0;}
+        if (data[7] == -1) {data[7] = 0;}
 
 
-        data[8] += pow(2,i); //Binary rep of which solenoid shorts, so if all fail all can be logged at once
+        data[7] += pow(2,i); //Binary rep of which solenoid shorts, so if all fail all can be logged at once
         //so if solenoid 1 fails, data[8] is dec(10) = 1, if 1 & 3 fail, data[8] is dec(1010) = 10
 
 
@@ -190,6 +190,9 @@ namespace Solenoids {
       }
     
     }
+       //data[7] += 5;
+       //Serial.println(data[7]);
+
     }
 
   bool loxArmed() {

--- a/lib/solenoids/solenoids.cpp
+++ b/lib/solenoids/solenoids.cpp
@@ -159,7 +159,7 @@ namespace Solenoids {
     data[7] = _pressurantSolenoidMonitor->getInputVoltage();
     data[8] = -1;
   }
-    void overCurrentCheck(float *data, int current_limit) {
+    void overCurrentCheck(float *data, float current_limit) {
 
     /*
     LOX2Way: Arming valve

--- a/lib/solenoids/solenoids.cpp
+++ b/lib/solenoids/solenoids.cpp
@@ -140,8 +140,8 @@ namespace Solenoids {
     data[4] = lox_G.outputMonitor.readShuntCurrent();
     data[5] = prop_G.outputMonitor.readShuntCurrent();
     data[6] = _pressurantSolenoidMonitor->getLoadCurrent(_pressurantSolenoidMonitorShuntR);
-    data[7] = -1;
-    data[8] = -1;
+    data[7] = 0;
+    data[8] = 0;
   }
 
   void getAllVoltages(float *data) {

--- a/lib/solenoids/solenoids.cpp
+++ b/lib/solenoids/solenoids.cpp
@@ -4,6 +4,7 @@
 */
 
 #include "solenoids.h"
+#include "math.h"
 
 using namespace std;
 
@@ -158,6 +159,38 @@ namespace Solenoids {
     data[7] = _pressurantSolenoidMonitor->getInputVoltage();
     data[8] = -1;
   }
+    void overCurrentCheck(float *data, int current_limit) {
+
+    /*
+    LOX2Way: Arming valve
+    Prop2Way: ignitor \shrug
+    LOX5Way: main valve for LOX
+    Prop5Way: main valve for prop
+    */
+    for (int i = 0; i < 4; i++) {
+      //Serial.print("current"+(String)i + "  " + (String)data[i]+"\n");
+      if (data[i] > current_limit) {
+        Serial.println("triggered " + (String)i);
+        switch (i) {
+          case 0 : if (toggleLOX2Way()==1) {toggleLOX2Way();} break;//if on, turn off; if off, make sure its off
+          case 1 : if (toggleProp2Way()==1) {toggleProp2Way();} break;
+          case 2 : closeLOX(); break;
+          case 3 : closePropane();break;
+        }
+
+        data[7] = 1; //flag for if there's an issue: usually 0
+        if (data[8] == -1) {data[8] = 0;}
+
+
+        data[8] += pow(2,i); //Binary rep of which solenoid shorts, so if all fail all can be logged at once
+        //so if solenoid 1 fails, data[8] is dec(10) = 1, if 1 & 3 fail, data[8] is dec(1010) = 10
+
+
+
+      }
+    
+    }
+    }
 
   bool loxArmed() {
     return lox2_state == 1;

--- a/lib/solenoids/solenoids.cpp
+++ b/lib/solenoids/solenoids.cpp
@@ -358,6 +358,7 @@ namespace Solenoids {
   }
 
   int armPropane() {
+    digitalWrite(lox_gems_pin, 1);
     if (prop2_state == 0) {
       toggleProp2Way();
     } else {
@@ -367,6 +368,7 @@ namespace Solenoids {
   }
 
   int disarmPropane() {
+    digitalWrite(lox_gems_pin, 0);
     if (prop2_state == 1) {
       toggleProp2Way();
     } else {
@@ -385,7 +387,7 @@ namespace Solenoids {
 
   int openLOX() {
 
-    digitalWrite(lox_gems_pin, 1);
+    //digitalWrite(lox_gems_pin, 1);
 
     if (lox5_state == 0) {
       toggleLOX5Way();
@@ -397,7 +399,7 @@ namespace Solenoids {
 
   int closeLOX() {
 
-    digitalWrite(lox_gems_pin, 0);
+    //digitalWrite(lox_gems_pin, 0);
 
     if (lox5_state == 1) {
       toggleLOX5Way();

--- a/lib/solenoids/solenoids.h
+++ b/lib/solenoids/solenoids.h
@@ -71,6 +71,7 @@ namespace Solenoids {
   int getPropGems();
   void getAllStates(float *data);
   void getAllCurrents(float *data);
+  void overCurrentCheck(float *data, int current_limit);
   void getAllVoltages(float *data);
   bool loxArmed();
   bool propArmed();

--- a/lib/solenoids/solenoids.h
+++ b/lib/solenoids/solenoids.h
@@ -98,7 +98,7 @@ namespace Solenoids {
 
       void initINA219(TwoWire *wire, uint8_t inaAddr, float shuntR, float maxExpectedCurrent) {
         outputMonitor.begin(wire, inaAddr);
-        outputMonitor.configure(INA219_RANGE_16V, INA219_GAIN_40MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
+        outputMonitor.configure(INA219_RANGE_32V, INA219_GAIN_160MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
         outputMonitor.calibrate(shuntR, maxExpectedCurrent);
       }
 

--- a/lib/solenoids/solenoids.h
+++ b/lib/solenoids/solenoids.h
@@ -71,7 +71,7 @@ namespace Solenoids {
   int getPropGems();
   void getAllStates(float *data);
   void getAllCurrents(float *data);
-  void overCurrentCheck(float *data, int current_limit);
+  void overCurrentCheck(float *data, float current_limit);
   void getAllVoltages(float *data);
   bool loxArmed();
   bool propArmed();

--- a/lib/tempController/tempController.h
+++ b/lib/tempController/tempController.h
@@ -126,7 +126,7 @@ class HeaterCommand : public Command, public TempController {
     float readBusVoltage() {
       return outputMonitor.readBusVoltage();
     }
-  float checkOvercurrent(float currentDraw, float maxCurrent) {
+  float checkOverCurrent(float currentDraw, float maxCurrent) {
       if (currentDraw > maxCurrent) {
         humanOverride = true; //heater is turned off, until another human signal is sent/control loop toggle is resent
         humanSpecifiedValue = 0;

--- a/lib/tempController/tempController.h
+++ b/lib/tempController/tempController.h
@@ -126,7 +126,15 @@ class HeaterCommand : public Command, public TempController {
     float readBusVoltage() {
       return outputMonitor.readBusVoltage();
     }
-
+  float checkOvercurrent(float currentDraw, float maxCurrent) {
+      if (currentDraw > maxCurrent) {
+        humanOverride = true; //heater is turned off, until another human signal is sent/control loop toggle is resent
+        humanSpecifiedValue = 0;
+        controlTemp(0); //to trigger controlTemp and set pin to 0
+        return 1;
+      }
+      return 0;
+    }
     void initINA219(TwoWire *wire, uint8_t inaAddr, float shuntR, float maxExpectedCurrent) {
       outputMonitor.begin(wire, inaAddr);
       outputMonitor.configure(INA219_RANGE_32V, INA219_GAIN_40MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);

--- a/lib/tempController/tempController.h
+++ b/lib/tempController/tempController.h
@@ -137,7 +137,7 @@ class HeaterCommand : public Command, public TempController {
     }
     void initINA219(TwoWire *wire, uint8_t inaAddr, float shuntR, float maxExpectedCurrent) {
       outputMonitor.begin(wire, inaAddr);
-      outputMonitor.configure(INA219_RANGE_32V, INA219_GAIN_40MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
+      outputMonitor.configure(INA219_RANGE_32V, INA219_GAIN_160MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
       outputMonitor.calibrate(shuntR, maxExpectedCurrent);
     }
 };

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,8 @@ lib_deps =
 	greiman/SdFat@^2.0.4
 	adafruit/Adafruit BMP3XX Library@^2.0.1
 
+extra_scripts = pre:fw_version.py
+
 ; [env:E1_coldflow]
 ; src_filter = -<*> +<E1_coldflow/>
 ; build_flags = -DHAL=teensy -DDEBUG  -DETH ; -DSERIAL_INPUT_DEBUG

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,49 +24,15 @@ lib_deps =
 
 extra_scripts = pre:fw_version.py
 
-; [env:E1_coldflow]
-; src_filter = -<*> +<E1_coldflow/>
-; build_flags = -DHAL=teensy -DDEBUG  -DETH ; -DSERIAL_INPUT_DEBUG
-
-[env:E1_coldflow_v2]
-src_filter = -<*> +<E1_coldflow_v2/>
-build_flags = -DHAL=teensy -DETH ; -DDEBUG ; -DSERIAL_INPUT_DEBUG
-
-[env:E1_coldflow_v21]
-src_filter = -<*> +<E1_coldflow_v21/>
-build_flags = -DHAL=teensy -DETH ; -DSERIAL_INPUT_DEBUG ; -DDEBUG ; 
-
-[env:E1_hotfire_v2]
-src_filter = -<*> +<E1_hotfire_v2/>
-build_flags = -DHAL=teensy -DETH ; -DDEBUG ; -DSERIAL_INPUT_DEBUG
 
 [env:E1_hotfire_mvp]
 src_filter = -<*> +<E1_hotfire_mvp/>
 build_flags = -DHAL=teensy -DETH ; -DDEBUG ; -DSERIAL_INPUT_DEBUG
 
-; [env:E1_coldflow_spoof]
-; src_filter = -<*> +<E1_coldflow/>
-; build_flags = -DHAL=native -DDEBUG ; -DETH ; -DSERIAL_INPUT_DEBUG
-
-[env:E1_coldflow_v2_spoof]
-src_filter = -<*> +<E1_coldflow_v2/>
-build_flags = -DHAL=native -DDEBUG ; -DETH  ; -DSERIAL_INPUT_DEBUG
-
-; [env:E1_waterflow]
-; src_filter = -<*> +<E1_waterflow/>
-; build_flags = -DHAL=teensy -DDEBUG ; -DETH ; -DSERIAL_INPUT_DEBUG
-
-[env:E1_waterflow_v2]
-src_filter = -<*> +<E1_waterflow_v2/>
-build_flags = -DHAL=teensy -DETH ; -DDEBUG -DSERIAL_INPUT_DEBUG
 
 [env:DAQ]
 src_filter = -<*> +<DAQ/>
 build_flags = -DHAL=teensy -DETH ;-DDEBUG ;-DETH ; -DSERIAL_INPUT_DEBUG
-
-[env:DAQ_spoof]
-src_filter = -<*> +<DAQ/>
-build_flags = -DHAL=native -DDEBUG ; -DETH ; -DSERIAL_INPUT_DEBUG
 
 [env:AC1]
 src_filter = -<*> +<ActuatorController/>
@@ -79,10 +45,6 @@ build_flags = -DHAL=teensy -DDEBUG -DAC2 -DETH ; -DSERIAL_INPUT_DEBUG
 [env:AC3]
 src_filter = -<*> +<ActuatorController/>
 build_flags = -DHAL=teensy -DDEBUG -DAC3 -DETH ; -DSERIAL_INPUT_DEBUG
-
-[env:lad4_1]
-src_filter = -<*> +<LAD4_1/>
-build_flags = -DHAL=teensy -DDEBUG ; -DSERIAL_INPUT_DEBUG
 
 [env:test_adc]
 src_filter = -<*> +<tests/ADC8167_test/>

--- a/src/ActuatorController/config.h
+++ b/src/ActuatorController/config.h
@@ -128,7 +128,7 @@ namespace config {
     debug("Initializing Power Supply monitors");
     for (int i = 0; i < numPowerSupplyMonitors; i++) {
         powerSupplyMonitors[i].begin(&Wire1, powSupMonAddrs[i]);
-        powerSupplyMonitors[i].configure(INA219_RANGE_16V, INA219_GAIN_40MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
+        powerSupplyMonitors[i].configure(INA219_RANGE_32V, INA219_GAIN_160MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
         powerSupplyMonitors[i].calibrate(powerSupplyMonitorShuntR, powerSupplyMonitorMaxExpectedCurrent);
         powSupMonPointers[i] = &powerSupplyMonitors[i];
     }

--- a/src/DAQ/config.h
+++ b/src/DAQ/config.h
@@ -86,7 +86,7 @@ namespace config {
     debug("Initializing Power Supply monitors");
     for (int i = 0; i < numPowerSupplyMonitors; i++) {
         powerSupplyMonitors[i].begin(&Wire, powSupMonAddrs[i]);
-        powerSupplyMonitors[i].configure(INA219_RANGE_16V, INA219_GAIN_40MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
+        powerSupplyMonitors[i].configure(INA219_RANGE_32V, INA219_GAIN_160MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
         powerSupplyMonitors[i].calibrate(powerSupplyMonitorShuntR, powerSupplyMonitorMaxExpectedCurrent);
         powSupMonPointers[i] = &powerSupplyMonitors[i];
     }

--- a/src/E1_hotfire_mvp/E1_hotfire_mvp.cpp
+++ b/src/E1_hotfire_mvp/E1_hotfire_mvp.cpp
@@ -303,7 +303,8 @@ void sensorReadFunc(int id) {
       farrbconvert.sensorReadings[1] = loxTankPTHeater.controlTemp(farrbconvert.sensorReadings[0]); // heater is not used for waterflows.
       farrbconvert.sensorReadings[2] = loxTankPTHeater.readCurrentDraw();
       farrbconvert.sensorReadings[3] = loxTankPTHeater.readBusVoltage();
-      farrbconvert.sensorReadings[4] = -1;
+      farrbconvert.sensorReadings[4] = loxTankPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      break;
       break;
     case 1:
       debug("Ducers");
@@ -346,7 +347,8 @@ void sensorReadFunc(int id) {
       farrbconvert.sensorReadings[1] = propTankPTHeater.controlTemp(farrbconvert.sensorReadings[0]); // heater is not used for waterflows.
       farrbconvert.sensorReadings[2] = propTankPTHeater.readCurrentDraw();
       farrbconvert.sensorReadings[3] = propTankPTHeater.readBusVoltage();
-      farrbconvert.sensorReadings[4] = -1;
+      farrbconvert.sensorReadings[4] = propTankPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      break;
       break;
     case 17:
       debug("static P");
@@ -360,12 +362,13 @@ void sensorReadFunc(int id) {
       farrbconvert.sensorReadings[1] = loxInjectorPTHeater.controlTemp(farrbconvert.sensorReadings[0]); // heater is not used for waterflows.
       farrbconvert.sensorReadings[2] = loxInjectorPTHeater.readCurrentDraw();
       farrbconvert.sensorReadings[3] = loxInjectorPTHeater.readBusVoltage();
-      farrbconvert.sensorReadings[4] = -1;
+      farrbconvert.sensorReadings[4] = loxInjectorPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+
       break;
     case 21:
       debug("solenoid currents");
       Solenoids::getAllCurrents(farrbconvert.sensorReadings);
-      Solenoids::overCurrentCheck(farrbconvert.sensorReadings, 1);
+      Solenoids::overCurrentCheck(farrbconvert.sensorReadings, maxSolenoidCurrent);
       if(Automation::inStartup()) {
         // check if igniter went off
         Automation::igniterGood = farrbconvert.sensorReadings[1] > 0.06 || Automation::igniterGood;
@@ -381,7 +384,8 @@ void sensorReadFunc(int id) {
       farrbconvert.sensorReadings[1] = propInjectorPTHeater.controlTemp(farrbconvert.sensorReadings[0]); // heater is not used for waterflows.
       farrbconvert.sensorReadings[2] = propInjectorPTHeater.readCurrentDraw();
       farrbconvert.sensorReadings[3] = propInjectorPTHeater.readBusVoltage();
-      farrbconvert.sensorReadings[4] = -1;
+      farrbconvert.sensorReadings[4] = propInjectorPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      break;
       break;
     default:
       Serial.println("some other sensor");

--- a/src/E1_hotfire_mvp/E1_hotfire_mvp.cpp
+++ b/src/E1_hotfire_mvp/E1_hotfire_mvp.cpp
@@ -365,6 +365,7 @@ void sensorReadFunc(int id) {
     case 21:
       debug("solenoid currents");
       Solenoids::getAllCurrents(farrbconvert.sensorReadings);
+      Solenoids::overCurrentCheck(farrbconvert.sensorReadings, 1);
       if(Automation::inStartup()) {
         // check if igniter went off
         Automation::igniterGood = farrbconvert.sensorReadings[1] > 0.06 || Automation::igniterGood;

--- a/src/E1_hotfire_mvp/E1_hotfire_mvp.cpp
+++ b/src/E1_hotfire_mvp/E1_hotfire_mvp.cpp
@@ -387,3 +387,11 @@ void sensorReadFunc(int id) {
       break;
   }
 }
+
+/*
+ * Slow down rate of readings of thermocouple sensors
+ */
+int changeThermoReadRate() {
+  sensor_checks[4][0] = 0; //4 is index of thermocouple packet
+  return 0; //isn't used
+}

--- a/src/E1_hotfire_mvp/E1_hotfire_mvp.cpp
+++ b/src/E1_hotfire_mvp/E1_hotfire_mvp.cpp
@@ -303,7 +303,9 @@ void sensorReadFunc(int id) {
       farrbconvert.sensorReadings[1] = loxTankPTHeater.controlTemp(farrbconvert.sensorReadings[0]); // heater is not used for waterflows.
       farrbconvert.sensorReadings[2] = loxTankPTHeater.readCurrentDraw();
       farrbconvert.sensorReadings[3] = loxTankPTHeater.readBusVoltage();
-      //farrbconvert.sensorReadings[4] = loxTankPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      farrbconvert.sensorReadings[4] = loxTankPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      farrbconvert.sensorReadings[5] = -1;
+
       break;
       break;
     case 1:
@@ -347,7 +349,8 @@ void sensorReadFunc(int id) {
       farrbconvert.sensorReadings[1] = propTankPTHeater.controlTemp(farrbconvert.sensorReadings[0]); // heater is not used for waterflows.
       farrbconvert.sensorReadings[2] = propTankPTHeater.readCurrentDraw();
       farrbconvert.sensorReadings[3] = propTankPTHeater.readBusVoltage();
-      //farrbconvert.sensorReadings[4] = propTankPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      farrbconvert.sensorReadings[4] = propTankPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      farrbconvert.sensorReadings[5] = -1;
       break;
       break;
     case 17:
@@ -362,14 +365,16 @@ void sensorReadFunc(int id) {
       farrbconvert.sensorReadings[1] = loxInjectorPTHeater.controlTemp(farrbconvert.sensorReadings[0]); // heater is not used for waterflows.
       farrbconvert.sensorReadings[2] = loxInjectorPTHeater.readCurrentDraw();
       farrbconvert.sensorReadings[3] = loxInjectorPTHeater.readBusVoltage();
-      //farrbconvert.sensorReadings[4] = loxInjectorPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      farrbconvert.sensorReadings[4] = loxInjectorPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      farrbconvert.sensorReadings[5] = -1;
 
       break;
     case 21:
       debug("solenoid currents");
       Solenoids::getAllCurrents(farrbconvert.sensorReadings);
-      //Solenoids::overCurrentCheck(farrbconvert.sensorReadings, maxSolenoidCurrent);
-      Serial.println("pl");
+    
+      Solenoids::overCurrentCheck(farrbconvert.sensorReadings, maxSolenoidCurrent);
+      //Serial.println("pl");
       if(Automation::inStartup()) {
         // check if igniter went off
         Automation::igniterGood = farrbconvert.sensorReadings[1] > 0.06 || Automation::igniterGood;
@@ -385,7 +390,9 @@ void sensorReadFunc(int id) {
       farrbconvert.sensorReadings[1] = propInjectorPTHeater.controlTemp(farrbconvert.sensorReadings[0]); // heater is not used for waterflows.
       farrbconvert.sensorReadings[2] = propInjectorPTHeater.readCurrentDraw();
       farrbconvert.sensorReadings[3] = propInjectorPTHeater.readBusVoltage();
-      //farrbconvert.sensorReadings[4] = propInjectorPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      farrbconvert.sensorReadings[4] = propInjectorPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      farrbconvert.sensorReadings[5] = -1;
+
       break;
       break;
     default:

--- a/src/E1_hotfire_mvp/E1_hotfire_mvp.cpp
+++ b/src/E1_hotfire_mvp/E1_hotfire_mvp.cpp
@@ -303,7 +303,7 @@ void sensorReadFunc(int id) {
       farrbconvert.sensorReadings[1] = loxTankPTHeater.controlTemp(farrbconvert.sensorReadings[0]); // heater is not used for waterflows.
       farrbconvert.sensorReadings[2] = loxTankPTHeater.readCurrentDraw();
       farrbconvert.sensorReadings[3] = loxTankPTHeater.readBusVoltage();
-      farrbconvert.sensorReadings[4] = loxTankPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      //farrbconvert.sensorReadings[4] = loxTankPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
       break;
       break;
     case 1:
@@ -347,7 +347,7 @@ void sensorReadFunc(int id) {
       farrbconvert.sensorReadings[1] = propTankPTHeater.controlTemp(farrbconvert.sensorReadings[0]); // heater is not used for waterflows.
       farrbconvert.sensorReadings[2] = propTankPTHeater.readCurrentDraw();
       farrbconvert.sensorReadings[3] = propTankPTHeater.readBusVoltage();
-      farrbconvert.sensorReadings[4] = propTankPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      //farrbconvert.sensorReadings[4] = propTankPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
       break;
       break;
     case 17:
@@ -362,13 +362,14 @@ void sensorReadFunc(int id) {
       farrbconvert.sensorReadings[1] = loxInjectorPTHeater.controlTemp(farrbconvert.sensorReadings[0]); // heater is not used for waterflows.
       farrbconvert.sensorReadings[2] = loxInjectorPTHeater.readCurrentDraw();
       farrbconvert.sensorReadings[3] = loxInjectorPTHeater.readBusVoltage();
-      farrbconvert.sensorReadings[4] = loxInjectorPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      //farrbconvert.sensorReadings[4] = loxInjectorPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
 
       break;
     case 21:
       debug("solenoid currents");
       Solenoids::getAllCurrents(farrbconvert.sensorReadings);
-      Solenoids::overCurrentCheck(farrbconvert.sensorReadings, maxSolenoidCurrent);
+      //Solenoids::overCurrentCheck(farrbconvert.sensorReadings, maxSolenoidCurrent);
+      Serial.println("pl");
       if(Automation::inStartup()) {
         // check if igniter went off
         Automation::igniterGood = farrbconvert.sensorReadings[1] > 0.06 || Automation::igniterGood;
@@ -384,7 +385,7 @@ void sensorReadFunc(int id) {
       farrbconvert.sensorReadings[1] = propInjectorPTHeater.controlTemp(farrbconvert.sensorReadings[0]); // heater is not used for waterflows.
       farrbconvert.sensorReadings[2] = propInjectorPTHeater.readCurrentDraw();
       farrbconvert.sensorReadings[3] = propInjectorPTHeater.readBusVoltage();
-      farrbconvert.sensorReadings[4] = propInjectorPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
+      //farrbconvert.sensorReadings[4] = propInjectorPTHeater.checkOverCurrent(farrbconvert.sensorReadings[2], maxPTHeaterCurrent);
       break;
       break;
     default:

--- a/src/E1_hotfire_mvp/config.h
+++ b/src/E1_hotfire_mvp/config.h
@@ -83,7 +83,7 @@ const uint8_t numHeaters = 6;
 uint8_t heaterChannels[numHeaters] = {2, 3, 1, 0, 4, 5};
 uint8_t heaterCommandIds[numHeaters] = {40, 41, 45, 42, 43, 44};
 uint8_t heaterINAAddrs[numHeaters] = {0x4B, 0x4C, 0x4A, 0x49, 0x4D, 0x4E};
-float maxPTHeaterCurrent = 4.0;
+float maxPTHeaterCurrent = 3.0;
 //removed 0x4E,
 // uint8_t heaterINAAddr[numHeaters] = {0x42, 0x43};
 
@@ -104,7 +104,7 @@ uint8_t solenoidPins[numSolenoids] = {5,  3,  1,  4,  2,  0, 6, 39};
 const uint8_t numSolenoidCommands = 10;    //       l2, l5, lg, p2, p5, pg,  h, arm, launch , h enable
 uint8_t solenoidCommandIds[numSolenoidCommands] = {20, 21, 22, 23, 24, 25, 26,  27, 28     , 31};
 uint8_t solenoidINAAddrs[numSolenoids] = {0x40, 0x42, 0x44, 0x41, 0x43, 0x45};
-float maxSolenoidCurrent = 2.0;
+float maxSolenoidCurrent = 1.0;
 
 LTC4151 pressurantSolenoidMonitor;
 float pressurantSolMonShuntR = 0.02;

--- a/src/E1_hotfire_mvp/config.h
+++ b/src/E1_hotfire_mvp/config.h
@@ -134,8 +134,8 @@ Command *backingStore[numCommands] = {&Solenoids::lox_2,  &Solenoids::lox_5,  &S
 CommandArray commands(numCommands, backingStore);
 
 // Automation
-Automation::autoEvent autoEvents[13];
-const int burnTime = 30*1000;
+Automation::autoEvent autoEvents[16];
+const int burnTime = 3*1000;
 
 namespace config {
   void setup() {
@@ -209,11 +209,11 @@ namespace config {
 
 
     debug("Initializing Shutdown Sequence");
-    autoEvents[10] = {0, &(Automation::act_armCloseProp), false};
-    autoEvents[11] = {200, &(Solenoids::closeLOX), false};
-    autoEvents[12] = {0, &(Automation::act_depressurize), false};
-    autoEvents[13] = {650, &(Solenoids::disarmLOX), false};
-    autoEvents[14] = {0, &(Automation::state_setFlowOver), false};
+    autoEvents[11] = {0, &(Automation::act_armCloseProp), false};
+    autoEvents[12] = {200, &(Solenoids::closeLOX), false};
+    autoEvents[13] = {0, &(Automation::act_depressurize), false};
+    autoEvents[14] = {650, &(Solenoids::disarmLOX), false};
+    autoEvents[15] = {0, &(Automation::state_setFlowOver), false};
 
 
     // autoEvents[5] = {300, &(Automation::state_setFlowing), false};

--- a/src/E1_hotfire_mvp/config.h
+++ b/src/E1_hotfire_mvp/config.h
@@ -149,7 +149,7 @@ namespace config {
     debug("Initializing Power Supply monitors");
     for (int i = 0; i < numPowerSupplyMonitors; i++) {
         powerSupplyMonitors[i].begin(&Wire, powSupMonAddrs[i]);
-        powerSupplyMonitors[i].configure(INA219_RANGE_32V, INA219_GAIN_40MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
+        powerSupplyMonitors[i].configure(INA219_RANGE_32V, INA219_GAIN_160MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
         powerSupplyMonitors[i].calibrate(powerSupplyMonitorShuntR, powerSupplyMonitorMaxExpectedCurrent);
         powSupMonPointers[i] = &powerSupplyMonitors[i];
     }

--- a/src/E1_hotfire_mvp/config.h
+++ b/src/E1_hotfire_mvp/config.h
@@ -134,7 +134,7 @@ Command *backingStore[numCommands] = {&Solenoids::lox_2,  &Solenoids::lox_5,  &S
 CommandArray commands(numCommands, backingStore);
 
 // Automation
-Automation::autoEvent autoEvents[16];
+Automation::autoEvent autoEvents[15];
 const int burnTime = 3*1000;
 
 namespace config {
@@ -194,26 +194,25 @@ namespace config {
   
     // Automation Sequences
     debug("Initializing Ignition Sequence");
-    autoEvents[0] = {0, &(Automation::act_closeGems), false};
-    autoEvents[1] = {2300, &(Automation::act_pressurizeTanks), false};
-    autoEvents[2] = {1000, &(Solenoids::armAll), false}; // igniter
-    autoEvents[3] = {2000, &(Automation::act_armOpenBoth), false}; //checks for igniter current, if enabled. 
-    autoEvents[4] = {0, &(Solenoids::openPropane), false}; // T-0
-    autoEvents[5] = {750, &(Automation::state_setFlowing), false};
-    autoEvents[6] = {burnTime - 750, &(Solenoids::closePropane), false};
-    autoEvents[7] = {0, &(Automation::state_setShutdown), false};
-    autoEvents[8] = {200, &(Solenoids::closeLOX), false};
-    autoEvents[9] = {650, &(Automation::act_depressurize), false};
-    autoEvents[10] = {0, &(Automation::state_setFlowOver), false};
+    autoEvents[0] = {1000, &(Solenoids::armAll), false}; // igniter
+    autoEvents[1] = {2000, &(Automation::act_armOpenBoth), false}; //checks for igniter current, if enabled. 
+    autoEvents[2] = {0, &(Solenoids::openPropane), false}; // T-0
+    autoEvents[3] = {750, &(Automation::state_setFlowing), false};
+    autoEvents[4] = {burnTime - 750, &(Solenoids::closePropane), false};
+    autoEvents[5] = {0, &(Automation::state_setShutdown), false};
+    autoEvents[6] = {200, &(Solenoids::closeLOX), false};
+    autoEvents[7] = {650, &(Solenoids::disarmLOX), false};
+    autoEvents[8] = {0, &(Solenoids::disarmPropane), false};
+    autoEvents[9] = {0, &(Automation::state_setFlowOver), false};
     
 
 
     debug("Initializing Shutdown Sequence");
-    autoEvents[11] = {0, &(Automation::act_armCloseProp), false};
-    autoEvents[12] = {200, &(Solenoids::closeLOX), false};
-    autoEvents[13] = {0, &(Automation::act_depressurize), false};
-    autoEvents[14] = {650, &(Solenoids::disarmLOX), false};
-    autoEvents[15] = {0, &(Automation::state_setFlowOver), false};
+    autoEvents[10] = {0, &(Automation::act_armCloseProp), false};
+    autoEvents[11] = {200, &(Solenoids::closeLOX), false};
+    autoEvents[12] = {0, &(Automation::act_depressurize), false};
+    autoEvents[13] = {650, &(Solenoids::disarmLOX), false};
+    autoEvents[14] = {0, &(Automation::state_setFlowOver), false};
 
 
     // autoEvents[5] = {300, &(Automation::state_setFlowing), false};

--- a/src/E1_hotfire_mvp/config.h
+++ b/src/E1_hotfire_mvp/config.h
@@ -83,6 +83,7 @@ const uint8_t numHeaters = 6;
 uint8_t heaterChannels[numHeaters] = {2, 3, 1, 0, 4, 5};
 uint8_t heaterCommandIds[numHeaters] = {40, 41, 45, 42, 43, 44};
 uint8_t heaterINAAddrs[numHeaters] = {0x4B, 0x4C, 0x4A, 0x49, 0x4D, 0x4E};
+float maxPTHeaterCurrent = 4.0;
 //removed 0x4E,
 // uint8_t heaterINAAddr[numHeaters] = {0x42, 0x43};
 
@@ -103,6 +104,7 @@ uint8_t solenoidPins[numSolenoids] = {5,  3,  1,  4,  2,  0, 6, 39};
 const uint8_t numSolenoidCommands = 10;    //       l2, l5, lg, p2, p5, pg,  h, arm, launch , h enable
 uint8_t solenoidCommandIds[numSolenoidCommands] = {20, 21, 22, 23, 24, 25, 26,  27, 28     , 31};
 uint8_t solenoidINAAddrs[numSolenoids] = {0x40, 0x42, 0x44, 0x41, 0x43, 0x45};
+float maxSolenoidCurrent = 2.0;
 
 LTC4151 pressurantSolenoidMonitor;
 float pressurantSolMonShuntR = 0.02;

--- a/src/E1_hotfire_mvp/config.h
+++ b/src/E1_hotfire_mvp/config.h
@@ -97,6 +97,9 @@ HeaterCommand propInjectorPTHeater("propInjectorPTHeater", heaterCommandIds[2], 
 const uint8_t numSensors = 13;
 sensorInfo sensors[numSensors];
 
+//Slow down rate of readings of thermocouple sensors
+int changeThermoReadRate();
+
 // Solenoids
 const uint8_t numSolenoids = 8;   // l2, l5, lg, p2, p5, pg, h, h enable
 uint8_t solenoidPins[numSolenoids] = {5,  3,  1,  4,  2,  0, 6, 39};
@@ -118,12 +121,14 @@ const float actuatorMonitorShuntR = 0.033; // ohms
 AutomationSequenceCommand fullFlow("Perform Flow", 29, &(Automation::beginBothFlow), &(Automation::endBothFlow));
 AutomationSequenceCommand loxFlow("Perform LOX Flow", 30, &(Automation::beginLoxFlow), &(Automation::endLoxFlow));
 
-const uint8_t numCommands = 18;
+AutomationSequenceCommand toggleThermoRate("Toggle Read Rate", 65, &changeThermoReadRate, &changeThermoReadRate);
+
+const uint8_t numCommands = 19;
 Command *backingStore[numCommands] = {&Solenoids::lox_2,  &Solenoids::lox_5,  &Solenoids::lox_G,
                                         &Solenoids::prop_2, &Solenoids::prop_5, &Solenoids::prop_G,
                                         &Solenoids::high_p, &Solenoids::high_p_enable, &Solenoids::arm_rocket, &Solenoids::launch,
                                         &fullFlow, &loxFlow, &loxTankPTHeater, &loxGemsHeater, &loxInjectorPTHeater, &propTankPTHeater,
-                                        &propGemsHeater, &propInjectorPTHeater};
+                                        &propGemsHeater, &propInjectorPTHeater, &toggleThermoRate};
 CommandArray commands(numCommands, backingStore);
 
 // Automation

--- a/src/tests/INA219_HBRG_test/main.cpp
+++ b/src/tests/INA219_HBRG_test/main.cpp
@@ -25,7 +25,7 @@ void setup() {
 
   for (int i = 0; i < numINA219; i++) {
       powerSupplyMonitors[i].begin(&Wire, _addrs[i]);
-      powerSupplyMonitors[i].configure(INA219_RANGE_32V, INA219_GAIN_40MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
+      powerSupplyMonitors[i].configure(INA219_RANGE_32V, INA219_GAIN_160MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
       powerSupplyMonitors[i].calibrate(solenoidMonitorShunt, solenoidMonitorMaxCurrent);
   }
 

--- a/src/tests/INA219_test/main.cpp
+++ b/src/tests/INA219_test/main.cpp
@@ -17,7 +17,7 @@ void setup() {
 
   for (int i = 0; i < numINA219; i++) {
       powerSupplyMonitors[i].begin(&Wire1, _addrs[i]);
-      powerSupplyMonitors[i].configure(INA219_RANGE_32V, INA219_GAIN_40MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
+      powerSupplyMonitors[i].configure(INA219_RANGE_32V, INA219_GAIN_160MV, INA219_BUS_RES_12BIT, INA219_SHUNT_RES_12BIT_1S);
       powerSupplyMonitors[i].calibrate(solenoidMonitorShunt, solenoidMonitorMaxCurrent);
   }
 }


### PR DESCRIPTION
A bit of a big PR, but that's because it contains code from multiple features that were all tested this weekend. The features included in this PR are:

- Overcurrent protection on valves & heaters. Using limits of 2A for valves and 4A for heaters. Main goal is to prevent damage via any shorts on any of the valve channels. ([AVI-59](https://jira.berkeleyse.org/browse/AVI-59))
- Use teensy built in MAC address instead of hard-coded MAC address ([AVI-89](https://jira.berkeleyse.org/browse/AVI-89))
- Store commit hash in firmware and new packet (id 99) to allow dashboard to request commit hash & other metadata, like configured burn time ([AVI-37](https://jira.berkeleyse.org/browse/AVI-37))
- Ability to disable the collection of thermocouple packets using a new packet (id 65), to allow higher read rate of PTs and other sensors during burn ([AVI-75](https://jira.berkeleyse.org/browse/AVI-75))

Another change was to the main begin flow automation sequence. The autosequence was updated to remove any autoEvents that tried to open/close the High Pressure Solenoid or the GEMS valves (since neither are used). Both LEDs were also updated to turn on when the igniter is turned on, not when either main valve is turned on. 

This code was used during [TEST-25](https://jira.berkeleyse.org/browse/TEST-25), [TEST-26](https://jira.berkeleyse.org/browse/TEST-26), and [TEST-27](https://jira.berkeleyse.org/browse/TEST-27), and no firmware issues were noticed during any of these three cold flows. 