### PR TITLE
Hotfire4/firmware dev 11 10

### DIFF
--- a/lib/Automation/Automation.cpp
+++ b/lib/Automation/Automation.cpp
@@ -13,6 +13,7 @@ namespace Automation {
 
 
   const bool IGNITER_DETECT_ENABLED = true;
+  const bool BREAK_DETECT_ENABLED = true;
 
   //-----------------------Variables-----------------------
 
@@ -28,6 +29,7 @@ namespace Automation {
   uint32_t _shutdownTimer;
 
   bool igniterGood = false;
+  bool breakGood = false;
 
   // flow_type_t flowtype;
   // flow_state_t flowstate = ON_PAD;
@@ -188,31 +190,28 @@ namespace Automation {
 
   int act_openLox() {
 
-    if (IGNITER_DETECT_ENABLED) { 
-      if(igniterGood) {
-        Solenoids::openLOX();
-        return 0;
-      } else {
+    if (IGNITER_DETECT_ENABLED) {
+      if(!igniterGood) {
         return -2;
       }
-    } else {
-      Solenoids::openLOX();
+      if(BREAK_DETECT_ENABLED && !breakGood) {
+        return -3;
+      }
     }
+    Solenoids::openLOX();
   }
 
   int act_armOpenLox() {
     if (IGNITER_DETECT_ENABLED) { 
-      if(igniterGood) {
-        Solenoids::armLOX();
-        Solenoids::openLOX();
-        return 0;
-      } else {
+      if(!igniterGood) {
         return -2;
       }
-    } else {
-      Solenoids::armLOX();
-      Solenoids::openLOX();
-    }
+      if(BREAK_DETECT_ENABLED && !breakGood) {
+        return -3;
+      }
+    } 
+    Solenoids::armLOX();
+    Solenoids::openLOX();
   }
 
   int act_armOpenProp() {
@@ -225,19 +224,16 @@ namespace Automation {
     // flowstate = BOTH_FLOWING;
 
     if (IGNITER_DETECT_ENABLED) { 
-      if(igniterGood) {
-        Solenoids::armLOX();
-        Solenoids::openLOX();
-        Solenoids::openPropane();
-        return 0;
-      } else {
+      if(!igniterGood) {
         return -2;
       }
-    } else {
-      Solenoids::armLOX();
-      Solenoids::openLOX();
-      Solenoids::openPropane();
-    }
+      if(BREAK_DETECT_ENABLED && !breakGood) {
+        return -3;
+      }
+    }  
+    Solenoids::armLOX();
+    Solenoids::openLOX();
+    Solenoids::openPropane();
   }
 
   int act_armCloseProp() {
@@ -358,7 +354,7 @@ namespace Automation {
       Serial.println("not startup");
       Serial.flush();
     #endif
-  }
+    }
     return -1;
   }
 

--- a/lib/Automation/Automation.h
+++ b/lib/Automation/Automation.h
@@ -60,6 +60,7 @@ namespace Automation {
   extern uint32_t _shutdownTimer;
 
   extern bool igniterGood;
+  extern bool breakGood;
 
 
   /* Delays during startup sequence:

--- a/lib/INA219/teensy/INA219.cpp
+++ b/lib/INA219/teensy/INA219.cpp
@@ -162,7 +162,7 @@ float INA219::readShuntVoltage(void)
 
 float INA219::readBusVoltage(void)
 {
-    int16_t voltage;
+    uint16_t voltage;
 
     voltage = readRegister16(INA219_REG_BUSVOLTAGE);
     voltage >>= 3;

--- a/src/E1_hotfire_mvp/E1_hotfire_mvp.cpp
+++ b/src/E1_hotfire_mvp/E1_hotfire_mvp.cpp
@@ -391,8 +391,8 @@ void sensorReadFunc(int id) {
       debug("solenoid voltages");
       Solenoids::getAllVoltages(farrbconvert.sensorReadings);
       if(Automation::inStartup()) {
-        // check if igniter had current
-        Automation::breakGood = farrbconvert.sensorReadings[4] > -5 || Automation::breakGood;
+        // check if breakwire broke
+        Automation::breakGood = farrbconvert.sensorReadings[4] < 24 || Automation::breakGood;
       } else {
         Automation::breakGood = false;
       }

--- a/src/E1_hotfire_mvp/E1_hotfire_mvp.cpp
+++ b/src/E1_hotfire_mvp/E1_hotfire_mvp.cpp
@@ -214,11 +214,10 @@ void loop() {
       Automation::_autoEventTracker++;
 
       // If abort code is produced, jump to shutdown
-      if(res == -2) {
-        sendPacket57(11);
+      if(res < -1) {
+        sendPacket57(9-res);
         Automation::_autoEventTracker = AUTO_SHUTDOWN_START;
       }
-
     }
 
   }
@@ -391,6 +390,12 @@ void sensorReadFunc(int id) {
     case 22:
       debug("solenoid voltages");
       Solenoids::getAllVoltages(farrbconvert.sensorReadings);
+      if(Automation::inStartup()) {
+        // check if igniter had current
+        Automation::breakGood = farrbconvert.sensorReadings[4] > -5 || Automation::breakGood;
+      } else {
+        Automation::breakGood = false;
+      }
       break;
     case 60:
       debug("Prop Injector");

--- a/src/E1_hotfire_mvp/config.h
+++ b/src/E1_hotfire_mvp/config.h
@@ -104,10 +104,10 @@ int stopThermoReadRate();
 
 // Solenoids
 const uint8_t numSolenoids = 8;   // l2, l5, lg, p2, p5, pg, h, h enable
-uint8_t solenoidPins[numSolenoids] = {5,  3,  1,  4,  2,  0, 6, 39};
+uint8_t solenoidPins[numSolenoids] = {5,  3,  1,  4,  0,  2, 6, 39};
 const uint8_t numSolenoidCommands = 10;    //       l2, l5, lg, p2, p5, pg,  h, arm, launch , h enable
 uint8_t solenoidCommandIds[numSolenoidCommands] = {20, 21, 22, 23, 24, 25, 26,  27, 28     , 31};
-uint8_t solenoidINAAddrs[numSolenoids] = {0x40, 0x42, 0x44, 0x41, 0x43, 0x45};
+uint8_t solenoidINAAddrs[numSolenoids] = {0x40, 0x42, 0x44, 0x41, 0x45, 0x43};
 float maxSolenoidCurrent = 1.0;
 
 LTC4151 pressurantSolenoidMonitor;

--- a/src/E1_hotfire_mvp/config.h
+++ b/src/E1_hotfire_mvp/config.h
@@ -197,7 +197,7 @@ namespace config {
     debug("Initializing Ignition Sequence");
     autoEvents[0] = {1000, &(Solenoids::armAll), true, 8}; // igniter
     autoEvents[1] = {2000, &(Automation::act_armOpenLox), true, 2}; //checks for igniter current, if enabled.
-    autoEvents[2] = {115, &(Solenoids::openPropane), true, 3}; // T-0
+    autoEvents[2] = {165, &(Solenoids::openPropane), true, 3}; // T-0
     autoEvents[3] = {750, &(Automation::state_setFlowing), false, 0};
     autoEvents[4] = {250, &(Solenoids::disarmPropane), true, 10}; //turn off igniter 
     autoEvents[5] = {burnTime - 1000, &(Solenoids::closePropane), true, 5}; // must substract delay between "openPropane" & here

--- a/src/E1_hotfire_mvp/config.h
+++ b/src/E1_hotfire_mvp/config.h
@@ -197,13 +197,13 @@ namespace config {
     debug("Initializing Ignition Sequence");
     autoEvents[0] = {1000, &(Solenoids::armAll), true, 8}; // igniter
     autoEvents[1] = {2000, &(Automation::act_armOpenLox), true, 2}; //checks for igniter current, if enabled.
-    autoEvents[2] = {215, &(Solenoids::openPropane), true, 3}; // T-0
+    autoEvents[2] = {115, &(Solenoids::openPropane), true, 3}; // T-0
     autoEvents[3] = {750, &(Automation::state_setFlowing), false, 0};
-    autoEvents[4] = {burnTime - 750, &(Solenoids::closePropane), true, 5};
-    autoEvents[5] = {0, &(Automation::state_setShutdown), false, 0};
-    autoEvents[6] = {200, &(Solenoids::closeLOX), true, 4};
-    autoEvents[7] = {650, &(Solenoids::disarmLOX), true, 9};
-    autoEvents[8] = {0, &(Solenoids::disarmPropane), true, 10}; //turn off igniter 
+    autoEvents[4] = {250, &(Solenoids::disarmPropane), true, 10}; //turn off igniter 
+    autoEvents[5] = {burnTime - 1000, &(Solenoids::closePropane), true, 5}; // must substract delay from "openPropane" to here
+    autoEvents[6] = {0, &(Automation::state_setShutdown), false, 0};
+    autoEvents[7] = {200, &(Solenoids::closeLOX), true, 4};
+    autoEvents[8] = {650, &(Solenoids::disarmLOX), true, 9};
     autoEvents[9] = {0, &(Automation::state_setFlowOver), false, 0};
 
 

--- a/src/E1_hotfire_mvp/config.h
+++ b/src/E1_hotfire_mvp/config.h
@@ -104,10 +104,10 @@ int stopThermoReadRate();
 
 // Solenoids
 const uint8_t numSolenoids = 8;   // l2, l5, lg, p2, p5, pg, h, h enable
-uint8_t solenoidPins[numSolenoids] = {5,  3,  1,  4,  0,  2, 6, 39};
+uint8_t solenoidPins[numSolenoids] = {5,  3,  1,  0,  2,  4, 6, 39};
 const uint8_t numSolenoidCommands = 10;    //       l2, l5, lg, p2, p5, pg,  h, arm, launch , h enable
 uint8_t solenoidCommandIds[numSolenoidCommands] = {20, 21, 22, 23, 24, 25, 26,  27, 28     , 31};
-uint8_t solenoidINAAddrs[numSolenoids] = {0x40, 0x42, 0x44, 0x41, 0x45, 0x43};
+uint8_t solenoidINAAddrs[numSolenoids] = {0x40, 0x42, 0x44, 0x45, 0x43, 0x41};
 float maxSolenoidCurrent = 1.0;
 
 LTC4151 pressurantSolenoidMonitor;
@@ -200,7 +200,7 @@ namespace config {
     autoEvents[2] = {115, &(Solenoids::openPropane), true, 3}; // T-0
     autoEvents[3] = {750, &(Automation::state_setFlowing), false, 0};
     autoEvents[4] = {250, &(Solenoids::disarmPropane), true, 10}; //turn off igniter 
-    autoEvents[5] = {burnTime - 1000, &(Solenoids::closePropane), true, 5}; // must substract delay from "openPropane" to here
+    autoEvents[5] = {burnTime - 1000, &(Solenoids::closePropane), true, 5}; // must substract delay between "openPropane" & here
     autoEvents[6] = {0, &(Automation::state_setShutdown), false, 0};
     autoEvents[7] = {200, &(Solenoids::closeLOX), true, 4};
     autoEvents[8] = {650, &(Solenoids::disarmLOX), true, 9};

--- a/src/E1_hotfire_mvp/config.h
+++ b/src/E1_hotfire_mvp/config.h
@@ -135,7 +135,7 @@ Command *backingStore[numCommands] = {&Solenoids::lox_2,  &Solenoids::lox_5,  &S
 CommandArray commands(numCommands, backingStore);
 
 // Automation
-Automation::autoEvent autoEvents[15];
+Automation::autoEvent autoEvents[14];
 const int burnTime = 5*1000;
 
 namespace config {
@@ -213,8 +213,8 @@ namespace config {
     debug("Initializing Shutdown Sequence");
     autoEvents[10] = {0, &(Automation::act_armCloseProp), true, 7};
     autoEvents[11] = {200, &(Solenoids::closeLOX), true, 6};
-    autoEvents[12] = {0, &(Automation::act_depressurize), false, 0};
-    autoEvents[13] = {650, &(Solenoids::disarmLOX), false, 0};
+    autoEvents[12] = {650, &(Solenoids::disarmLOX), false, 0};
+    autoEvents[13] = {0, &(Solenoids::disarmPropane), false, 0}; //turn off igniter 
     autoEvents[14] = {0, &(Automation::state_setFlowOver), false, 0};
 
 


### PR DESCRIPTION
This PR includes changes that were made and used during acceptance testing campaign. Changes include:

- Adding detection of breakwire continuity going from closed -> open, and a flag that is set so that automation sequence can abort if there is no detected change in continuity. Enable/Disable flag is in Automation.cpp
- Updated INA219 library to correctly read bus voltages >15V - allows nominal continuity detection on 24V channels
- Added flag in Solenoids to enable or disable an LED channel being used as a breakwire - if true, the flight computer will not attempt to power the channel when the igniter is commanded on. 
- Updated automation sequence to have delay adequate for propane, as seen from testing. Last change was 165ms LOX lead